### PR TITLE
props/drops for individual snippets

### DIFF
--- a/client/src/pages/IndividualSnippet.jsx
+++ b/client/src/pages/IndividualSnippet.jsx
@@ -157,19 +157,21 @@ export default function UserSnippets() {
   const handleAddProps = async (snippetId) => {
     if (currentUser) {
       try {
-  
+        // Check if the user has already propped/dropped the snippet
         const userHasProp = snippets.props.includes(currentUser);
-  
+        const userHasDropped = snippets.drops.includes(currentUser);
+
         if (userHasProp) {
           // User has already propped, so remove the prop
           await removeProps({
             variables: {
               username: currentUser,
               snippetId: snippetId,
-              operation: userHasProp ? "REMOVE" : "ADD",
             },
           });
-        } else {
+        } else if (!userHasDropped) {
+          // user cannot prop if they have dropped, need to undrop first
+          // makes it so both buttons are not active at the same time
           // User hasn't propped, so add the prop
           await addProps({
             variables: {
@@ -203,17 +205,19 @@ export default function UserSnippets() {
       try {
 
           const userHasDropped = snippets.drops.includes(currentUser);
-  
+          const userHasProp = snippets.props.includes(currentUser);
+
         if (userHasDropped) {
           // User has already dropped, so remove the drop
           await removeDrops({
             variables: {
               username: currentUser,
               snippetId: snippetId,
-              operation: userHasDropped ? "REMOVE" : "ADD",
             },
           });
-        } else {
+        } else if (!userHasProp) {
+          // user cannot drop if they have propped, need to unprop first
+          // makes it so both buttons are not active at the same time
           // User hasn't dropped, so add the drop
           await addDrops({
             variables: {
@@ -227,36 +231,6 @@ export default function UserSnippets() {
       }
     }
   };
-
-  // const handleRemoveProps = async (snippetId) => {
-  //   if (currentUser) {
-  //     try {
-  //       await removeProps({
-  //         variables: {
-  //           username: currentUser,
-  //           snippetId: snippetId,
-  //         },
-  //       });
-  //     } catch (err) {
-  //       console.error(err);
-  //     }
-  //   }
-  // };
-
-  // const handleRemoveDrops = async (snippetId) => {
-  //   if (currentUser) {
-  //     try {
-  //       await removeDrops({
-  //         variables: {
-  //           username: currentUser,
-  //           snippetId: snippetId,
-  //         },
-  //       });
-  //     } catch (err) {
-  //       console.error(err);
-  //     }
-  //   }
-  // };
 
   return (
     <>

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -211,6 +211,7 @@ mutation RemoveProps($username: String!, $snippetId: ID!)
   {
     _id
     props
+    overallProps
   }
 }`;
 
@@ -246,6 +247,7 @@ mutation RemoveDrops($username: String!, $snippetId: ID!)
   {
     _id
     drops
+    overallProps
   }
 }`;
 


### PR DESCRIPTION
added logic for prop/drop buttons, button will highlight on click, to remove a prop/drop or unhighlight the button you have to click it again. two buttons cannot be activated at the same time. Can now remove a prop without adding a drop and vice versa. only for individual snippet page, need to apply to other pages. old code is commented out for now for reference, will be deleted on final clean up